### PR TITLE
:arrow_up: Bump Jackson dependencies to 2.18.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.14.2</version>
+      <version>2.18.3</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
-      <version>2.14.2</version>
+      <version>2.18.3</version>
     </dependency>
 
     <!-- Jackson module for JDK collections -->

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.15.1</version>
+      <version>2.18.3</version>
     </dependency>
 
     <!-- Jackson module for Java 8 date and time types -->

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jdk8</artifactId>
-      <version>2.14.2</version>
+      <version>2.18.3</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
This pull request includes updates to the `pom.xml` file to upgrade the versions of several Jackson dependencies. The changes ensure that the project uses the latest versions of these libraries for improved performance and security.

Dependency version upgrades:

* Updated `jackson-core` from version `2.14.2` to `2.18.3`.
* Updated `jackson-databind` from version `2.15.1` to `2.18.3`.
* Updated `jackson-datatype-jsr310` from version `2.14.2` to `2.18.3`.
* Updated `jackson-datatype-jdk8` from version `2.14.2` to `2.18.3`.