### PR TITLE
:arrow_up: Update the jitpack Java setting to 21

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -2,5 +2,5 @@
 #  - openjdk17
 before_install:
   - sdk update
-  - sdk install java 17.0.3-tem
-  - sdk use java 17.0.3-tem
+  - sdk install java 21.0.6-tem
+  - sdk use java 21.0.6-tem


### PR DESCRIPTION
This pull request includes a small change to the `jitpack.yml` file. The change updates the Java version used during the installation process.

* [`jitpack.yml`](diffhunk://#diff-1604193a5efbe3735c6ab8b44601ad6e42df52f6834bcc155650e3eef5b3fa94L5-R6): Updated the Java version from `17.0.3-tem` to `21.0.6-tem` for both installation and usage.